### PR TITLE
Update classic-0.1-1.rockspec

### DIFF
--- a/classic-0.1-1.rockspec
+++ b/classic-0.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "classic"
 version = "0.1-1"
 source = {
-  url = "git://github.com/rxi/classic",
+  url = "git://github.com/thefosk/classic",
   branch = "master"
 }
 description = {


### PR DESCRIPTION
The old repository is likely abandoned, so instead of modifying the file path, I set the download URL to the fork.
